### PR TITLE
Adds recording of issued requests

### DIFF
--- a/stub/storage.go
+++ b/stub/storage.go
@@ -20,14 +20,33 @@ type stubMapping map[string]map[string][]storage
 type matchFunc func(interface{}, interface{}) bool
 
 var stubStorage = stubMapping{}
+var requestStorage = []*request{}
 
 type storage struct {
 	Input  Input
 	Output Output
 }
 
+type request struct {
+	Record findStubPayload `json:"record"`
+	Count  int             `json:"count"`
+}
+
 func storeStub(stub *Stub) error {
 	return stubStorage.storeStub(stub)
+}
+
+func storeRequest(stub *findStubPayload) {
+	for _, v := range requestStorage {
+		if reflect.DeepEqual(v.Record, *stub) {
+			v.Count++
+			return
+		}
+	}
+	requestStorage = append(requestStorage, &request{
+		Record: *stub,
+		Count:  1,
+	})
 }
 
 func (sm *stubMapping) storeStub(stub *Stub) error {
@@ -51,6 +70,12 @@ func allStub() stubMapping {
 	return stubStorage
 }
 
+func allRequests() []*request {
+	mx.Lock()
+	defer mx.Unlock()
+	return requestStorage
+}
+
 type closeMatch struct {
 	rule   string
 	expect map[string]interface{}
@@ -59,6 +84,7 @@ type closeMatch struct {
 func findStub(stub *findStubPayload) (*Output, error) {
 	mx.Lock()
 	defer mx.Unlock()
+	storeRequest(stub)
 	if _, ok := stubStorage[stub.Service]; !ok {
 		return nil, fmt.Errorf("Can't find stub for Service: %s", stub.Service)
 	}
@@ -270,6 +296,7 @@ func clearStorage() {
 	defer mx.Unlock()
 
 	stubStorage = stubMapping{}
+	requestStorage = []*request{}
 }
 
 func readStubFromFile(path string) {

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	
+
 	"github.com/go-chi/chi"
 )
 
@@ -29,6 +29,7 @@ func RunStubServer(opt Options) {
 	r.Get("/", listStub)
 	r.Post("/find", handleFindStub)
 	r.Get("/clear", handleClearStub)
+	r.Get("/requests", listRequests)
 
 	if opt.StubPath != "" {
 		readStubFromFile(opt.StubPath)
@@ -106,7 +107,7 @@ func validateStub(stub *Stub) error {
 	if stub.Method == "" {
 		return fmt.Errorf("Method name can't be emtpy")
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
@@ -143,11 +144,11 @@ func handleFindStub(w http.ResponseWriter, r *http.Request) {
 		responseError(err, w)
 		return
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
-	
+
 	output, err := findStub(stub)
 	if err != nil {
 		log.Println(err)
@@ -162,4 +163,9 @@ func handleFindStub(w http.ResponseWriter, r *http.Request) {
 func handleClearStub(w http.ResponseWriter, r *http.Request) {
 	clearStorage()
 	w.Write([]byte("OK"))
+}
+
+func listRequests(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(allRequests())
 }

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -100,6 +100,14 @@ func TestStub(t *testing.T) {
 			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
 		},
 		{
+			name: "get recorded requests",
+			mock: func() *http.Request {
+				return httptest.NewRequest("GET", "/requests", nil)
+			},
+			handler: listRequests,
+			expect:  "[{\"record\":{\"service\":\"Testing\",\"method\":\"TestMethod\",\"data\":{\"Hola\":\"Mundo\"}},\"count\":1},{\"record\":{\"service\":\"NestedTesting\",\"method\":\"TestMethod\",\"data\":{\"age\":1,\"cities\":[\"Istanbul\",\"Jakarta\"],\"girl\":true,\"greetings\":{\"hola\":\"mundo\",\"merhaba\":\"dunya\"},\"name\":\"Afra Gokce\",\"null\":null}},\"count\":1}]\n",
+		},
+		{
 			name: "add stub contains",
 			mock: func() *http.Request {
 				payload := `{


### PR DESCRIPTION
This change adds a new GET endpoint `/requests` that returns the grpc calls made to the mock. It returns the service, methos and data plus the number of times the request has been issued.